### PR TITLE
autoload gfm-mode

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -2455,6 +2455,7 @@ This is an exact copy of `line-number-at-pos' for use in emacs21."
 
 ;;; GitHub Flavored Markdown Mode  ============================================
 
+;;;###autoload
 (define-derived-mode gfm-mode markdown-mode "GFM"
   "Major mode for editing GitHub Flavored Markdown files."
   (setq markdown-link-space-sub-char "-")


### PR DESCRIPTION
right now it requires to an autoload like the following to work. 

``` elisp
(autoload 'gfm-mode "markdown-mode")
```

It would be nice if it could be included.
