### PR TITLE
Fix void-variable error

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -951,7 +951,7 @@ text.")
   (append
    markdown-mode-font-lock-keywords
    (list
-    (cons markdown-match-quoted-code-blocks
+    (cons 'markdown-match-quoted-code-blocks
           '((0 markdown-pre-face t t)
             (1 markdown-language-keyword-face t t)
             (2 markdown-pre-face t t))))))


### PR DESCRIPTION
`markdown-match-quoted-code-blocks` is a function and must be quoted as such.

Note that I did not test this patch.
