### PR TITLE
Eliminate byte-compilation warning

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -4354,9 +4354,9 @@ This is an exact copy of `line-number-at-pos' for use in emacs21."
        '(gfm-font-lock-keywords))
   (auto-fill-mode 0)
   ;; Use visual-line-mode if available, fall back to longlines-mode:
-  (if (fboundp 'visual-line-mode)
-      (visual-line-mode 1)
-    (longlines-mode 1))
+  (funcall (eval-when-compile (if (fboundp 'visual-line-mode)
+                                  'visual-line-mode
+                                'longlines-mode)) 1)
   ;; do the initial link fontification
   (markdown-fontify-buffer-wiki-links))
 


### PR DESCRIPTION
This commit resolves the following warning in Emacs HEAD, in which no autoload exists for longlines-mode:

```
markdown-mode.el:4367:1:Warning: the function `longlines-mode' is not known to
    be defined.
```
